### PR TITLE
 [SonicFrontiers] Add "[Sonic] Always Perfect Parry" Code 

### DIFF
--- a/Source/Sonic Frontiers/Gameplay/[Sonic] Always Perfect Parry.hmm
+++ b/Source/Sonic Frontiers/Gameplay/[Sonic] Always Perfect Parry.hmm
@@ -1,0 +1,12 @@
+Code "[Sonic] Always Perfect Parry" by "ĐeäTh" in "Gameplay" does "Enables the perfect parry at all times for Sonic."
+///
+    #include "BlackboardStatus" noemit
+///
+{
+    var pBlackboardStatus = BlackboardStatus.Get();
+    if (pBlackboardStatus == null)
+        return;
+
+    if (!IS_COMBAT_FLAG(IsPerfectParry))
+        pBlackboardStatus->CombatFlags |= (1L << (int)BlackboardStatus.CombatFlags.IsPerfectParry);
+}

--- a/Source/Sonic Frontiers/Libraries/BlackboardStatus.hmm
+++ b/Source/Sonic Frontiers/Libraries/BlackboardStatus.hmm
@@ -19,6 +19,24 @@ Library "BlackboardStatus" by "Hyper" does "Provides access to `app::player::Bla
     /// <param name="in_name">The name of an enum member from the `StateFlags` enum.</param>
     /// <returns>A boolean value representing whether the state flag is set.</returns>
     #define IS_STATE_FLAG(in_name) (BlackboardStatus.Get() != null && (BlackboardStatus.Get()->StateFlags & (1L << (int)BlackboardStatus.StateFlags.in_name)) != 0)
+    
+    /// <summary>
+    /// Determines whether a combat flag is set.
+    /// </summary>
+    /// <example>
+    /// <code><![CDATA[
+    /// Code
+    /// //
+    ///     #include "BlackboardStatus" noemit
+    /// //
+    /// {
+    ///     bool isPerfectParry = IS_COMBAT_FLAG(IsPerfectParry);
+    /// }
+    /// ]]></code>
+    /// </example>
+    /// <param name="in_name">The name of an enum member from the `CombatFlags` enum.</param>
+    /// <returns>A boolean value representing whether the combat flag is set.</returns>
+    #define IS_COMBAT_FLAG(in_name) (BlackboardStatus.Get() != null && (BlackboardStatus.Get()->CombatFlags & (1L << (int)BlackboardStatus.CombatFlags.in_name)) != 0)
 
     /// <summary>
     /// Determines whether a world flag is set.
@@ -55,6 +73,11 @@ Library "BlackboardStatus" by "Hyper" does "Provides access to `app::player::Bla
         /// Determines if the current player is in their Super form.
         /// </summary>
         [FieldOffset(0x24)] public bool IsSuper;
+
+        /// <summary>
+        /// Bit flags representing combat statuses.
+        /// </summary>
+        [FieldOffset(0x28)] public long CombatFlags;
 
         /// <summary>
         /// Bit flags representing state statuses.
@@ -220,6 +243,17 @@ Library "BlackboardStatus" by "Hyper" does "Provides access to `app::player::Bla
         /// The player has Phantom Rush.
         /// </summary>
         IsPhantomRush = 0x26
+    }
+
+    /// <summary>
+    /// An enum containing known combat flags.
+    /// </summary>
+    public enum CombatFlags
+    {
+        /// <summary>
+        /// The player is using perfect parry.
+        /// </summary>
+        IsPerfectParry = 0x10
     }
 
     /// <summary>


### PR DESCRIPTION
Adds a code for Sonic Frontiers that allows the Perfect Parry to be always used by Sonic.