### PR TITLE
[Sonic Frontiers] Changes to "Retain Horizontal Velocity from Stomp"

### DIFF
--- a/Source/Sonic Frontiers/Physics/Retain Horizontal Velocity from Stomp.hmm
+++ b/Source/Sonic Frontiers/Physics/Retain Horizontal Velocity from Stomp.hmm
@@ -4,8 +4,8 @@ While holding down the stomp button, stomp partially retains your last horizonta
 
 Notes;
 - This will remove the cooldown before bounce jumps.
-- This will remove the shockwave from performing consecutive stomps
-- This does not affect the shockwave from 'Super Stomp'
+- This will remove the shockwave from performing consecutive stomps.
+- This does not affect the shockwave from the "Super Stomp" code.
 */
 //
     #lib "Sonic"

--- a/Source/Sonic Frontiers/Physics/Retain Horizontal Velocity from Stomp.hmm
+++ b/Source/Sonic Frontiers/Physics/Retain Horizontal Velocity from Stomp.hmm
@@ -1,12 +1,22 @@
-Code "Retain Horizontal Velocity from Stomp" by "WasifBoomz" in "Physics" does "Makes stomp partially retain your last horizontal velocity, rather than falling straight down."
+Code "Retain Horizontal Velocity from Stomp" by "WasifBoomz" in "Physics" does
+/*
+While holding down the stomp button, stomp partially retains your last horizontal velocity, rather than falling straight down.
+
+Notes;
+- This will remove the cooldown before bounce jumps.
+- This will remove the shockwave from performing consecutive stomps
+- This does not affect the shockwave from 'Super Stomp'
+*/
 //
     #lib "Sonic"
-    
+    #lib "Time"
+
     #load "System.Numerics.dll"
 
     using System.Numerics;
 
-    const float stompStopForce = 60.0f;
+    const float stompStopForce = 20.0f;
+    const float stompReleaseStopForce = 80.0f;
 
     static Vector3 prevVelocity;
 //
@@ -17,10 +27,11 @@ Code "Retain Horizontal Velocity from Stomp" by "WasifBoomz" in "Physics" does "
         return;
 
     float yVel = kinematics->Velocity.Y;
+    bool isStompDown = Player.Input.IsDown(Player.InputActionType.PlayerStomping);
 
     if (Player.State.GetCurrentStateID<Sonic.StateID>() == Sonic.StateID.StateStompingLand)
     {
-        if (Player.Input.IsDown(Player.InputActionType.PlayerStomping))
+        if (isStompDown)
             Player.State.SetState<Sonic.StateID>(Sonic.StateID.StateBounceJump);
         else
             Player.State.SetState<Sonic.StateID>(Sonic.StateID.StateRun);
@@ -33,7 +44,7 @@ Code "Retain Horizontal Velocity from Stomp" by "WasifBoomz" in "Physics" does "
         if (new Vector3(prevVelocity.X,0,prevVelocity.Z).Length() < stompStopForce * Time.GetDeltaTime())
             kinematics->Velocity = Vector3.Zero;
         else
-            kinematics->Velocity = Vector3.Normalize(new Vector3(prevVelocity.X, 0, prevVelocity.Z)) * (new Vector3(prevVelocity.X, 0, prevVelocity.Z).Length() - (stompStopForce * Time.GetDeltaTime()));
+            kinematics->Velocity = Vector3.Normalize(new Vector3(prevVelocity.X, 0, prevVelocity.Z)) * (new Vector3(prevVelocity.X, 0, prevVelocity.Z).Length() - ((isStompDown ? stompStopForce : stompReleaseStopForce) * Time.GetDeltaTime()));
         kinematics->Velocity.Y = yVel;
     }
 


### PR DESCRIPTION
- Reduced how much speed you lose
- Releasing stomp now makes you lose speed a lot faster
- Added "Time" library to resolve #49 and #50 
- Added notes