### PR TITLE
[Sonic Origins] Various S3&K Codes

### DIFF
--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/Disable Ring Loss From Super Hyper Forms.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/Disable Ring Loss From Super Hyper Forms.hmm
@@ -1,8 +1,11 @@
 Patch "Disable Ring Loss From Super/Hyper Forms" in "Cheats/Sonic 3 & Knuckles" by "MegAmi" does "Disables losing a ring every second while in a Super or Hyper form."
-//
-    #lib "Memory"
-//
 {
-    // 2.0.2: 0x1401DF8B7
-    Memory.WriteForceJump(ScanSignature("\x0F\x8F\x9E\x01\x00\x00\xFF\x8B\xD0\x00\x00\x00", "xxxxxxxxxxxx"));
+    // 2.0.2: 0x1401DF8BD
+    WriteNop(
+        ScanSignature
+        (
+            "\xFF\x8B\xD0\x00\x00\x00\xC7\x83\xF8\x01\x00\x00\x3C\x00\x00\x00",
+            "xxxxxxxxxxxxxxxx"
+        ),
+        6);
 }

--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/Disable Ring Loss From Super Hyper Forms.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/Disable Ring Loss From Super Hyper Forms.hmm
@@ -1,0 +1,8 @@
+Patch "Disable Ring Loss From Super/Hyper Forms" in "Cheats/Sonic 3 & Knuckles" by "MegAmi" does "Disables losing a ring every second while in a Super or Hyper form."
+//
+    #lib "Memory"
+//
+{
+    // 2.0.2: 0x1401DF8B7
+    Memory.WriteForceJump(ScanSignature("\x0F\x8F\x9E\x01\x00\x00\xFF\x8B\xD0\x00\x00\x00", "xxxxxxxxxxxx"));
+}

--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/Infinite Tails Flight.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/Infinite Tails Flight.hmm
@@ -1,0 +1,11 @@
+Patch "Infinite Tails Flight" in "Cheats/Sonic 3 & Knuckles" by "MegAmi" does "Disables the timer for Tails' flight ability, allowing him to fly without getting tired."
+{
+    // 2.0.2: 0x1401E83DD
+    WriteNop(
+        ScanSignature
+        (
+            "\xFF\x83\xAC\x01\x00\x00\x81\xBB\xAC\x01\x00\x00\xE0\x01\x00\x00\x75\x73\x48\x8B\x85\xF0\x00\x00\x00",
+            "xxxxxxxxxxxxxxxxxxxxxxxxx"
+        ),
+        6);
+}

--- a/Source/Sonic Origins/Fixes/Sonic 3 & Knuckles/Fix Star Post Fadeout.hmm
+++ b/Source/Sonic Origins/Fixes/Sonic 3 & Knuckles/Fix Star Post Fadeout.hmm
@@ -1,0 +1,45 @@
+Patch "Fix Star Post Fadeout" in "Fixes/Sonic 3 & Knuckles" by "MegAmi" does "Fixes the fadeout from Star Posts into Bonus Stages fading to white instead of black, and disables the warp sound effect that plays during it."
+{
+    // Disable the sound effect
+    // 2.0.2: 0x1401F9B26
+    WriteNop(
+        ScanSignature
+        (
+            "\xFF\x90\xD0\x04\x00\x00\x48\x8B\x05\x00\x00\x00\x00\xB1\x03",
+            "xxxxxxxxx????xx"
+        ),
+        6);
+
+    // Change the fade from white to black
+    // For some reason, there are separate functions for loading each bonus stage, so each one needs to be set individually
+
+    // Rotating Slot Bonus
+    // 2.0.2: 0x1401FD42E
+    WriteProtected<byte>(
+        ScanSignature
+        (
+            "\x48\x8D\x0D\x03\xAA\x99\x00\xFF\x90\xA8\x00\x00\x00\xBA\xF0\xF0\xF0\x00",
+            "xxxxxxxxxxxxxxxxxx"
+        ) + 0x0E,
+        0x00, 0x00, 0x00);
+
+    // Glowing Spheres Bonus
+    // 2.0.2: 0x1401FD32E
+    WriteProtected<byte>(
+        ScanSignature
+        (
+            "\x48\x8D\x0D\x03\xAB\x99\x00\xFF\x90\xA8\x00\x00\x00\xBA\xF0\xF0\xF0\x00",
+            "xxxxxxxxxxxxxxxxxx"
+        ) + 0x0E,
+        0x00, 0x00, 0x00);
+
+    // Gachapon Bonus
+    // 2.0.2: 0x1401FD2CE
+    WriteProtected<byte>(
+        ScanSignature
+        (
+            "\x48\x8D\x0D\x63\xAB\x99\x00\xFF\x90\xA8\x00\x00\x00\xBA\xF0\xF0\xF0\x00",
+            "xxxxxxxxxxxxxxxxxx"
+        ) + 0x0E,
+        0x00, 0x00, 0x00);
+}

--- a/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Disable Bonus Stages.hmm
+++ b/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Disable Bonus Stages.hmm
@@ -1,0 +1,8 @@
+Patch "Disable Bonus Stages" in "Gameplay/Sonic 3 & Knuckles" by "MegAmi" does "Removes the Bonus Stage stars from Star Posts."
+//
+    #lib "Memory"
+//
+{
+    // 2.0.2: 0x1401FA461
+    Memory.WriteForceJump(ScanSignature("\x0F\x8C\x28\x01\x00\x00\x83\xC1\xEC\xB8\x89\x88\x88\x88", "xxxxxxxxxxxxxx"));
+}

--- a/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Disable Cool Bonus.hmm
+++ b/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Disable Cool Bonus.hmm
@@ -1,0 +1,8 @@
+Patch "Disable Cool Bonus" in "Gameplay/Sonic 3 & Knuckles" by "MegAmi" does "Disables the leftover Cool score bonus from Sonic Mania."
+//
+    #lib "Memory"
+//
+{
+    // 2.0.2: 0x1401FF215
+    Memory.WriteForceJump(ScanSignature("\x75\x55\xC7\x81\x00\x00\x00\x00\x10\x27\x00\x00", "xxxx????xxxx"));
+}

--- a/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Items/Remove All Items.hmm
+++ b/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Items/Remove All Items.hmm
@@ -1,4 +1,4 @@
-Code "Remove All Items" in "Gameplay/Sonic 3 & Knuckles/Items" by "MegAmi" does "Removes all rings, monitors, starposts, and special rings from all stages."
+Code "Remove All Items" in "Gameplay/Sonic 3 & Knuckles/Items" by "MegAmi" does "Removes all rings, monitors, star posts, and special rings from all stages."
 //
     #lib "RSDK"
 //

--- a/Source/Sonic Origins/UI/Sonic 3 & Knuckles/Allow Amy in Classic Mode.hmm
+++ b/Source/Sonic Origins/UI/Sonic 3 & Knuckles/Allow Amy in Classic Mode.hmm
@@ -1,0 +1,48 @@
+Patch "Allow Amy in Classic Mode" in "UI/Sonic 3 & Knuckles" by "MegAmi" does
+/*
+Allows selecting and playing as Amy or Amy & Tails in Classic Mode if the Plus DLC is active.
+
+Notes;
+- Amy's Hammer Rush move will not activate in Classic Mode.
+*/
+{
+    // Set option to wrap to when pressing up from Sonic & Tails on No Save
+    // 2.0.2: 0x140307826
+    WriteNop(
+        ScanSignature
+        (
+            "\x0F\xB6\x83\x76\x01\x00\x00\x84\xC0",
+            "xxxxxxxxx"
+        ) - 17,
+        2);
+
+    // Set max option count when pressing down on No Save
+    // 2.0.2: 0x1403077E3
+    WriteNop(
+        ScanSignature
+        (
+            "\x0F\xBE\x93\x76\x01\x00\x00\x3B\xD1\x7D\x0A",
+            "xxxxxxxxxxx"
+        ) - 17,
+        2);
+
+    // Set option to wrap to when pressing up from Sonic & Tails on a save file
+    // 2.0.2: 0x140307CF3
+    WriteNop(
+        ScanSignature
+        (
+            "\x88\x83\x76\x01\x00\x00\xEB\x46",
+            "xxxxxxxx"
+        ) - 30,
+        2);
+
+    // Set max option count when pressing down on a save file
+    // 2.0.2: 0x140307C41
+    WriteNop(
+        ScanSignature
+        (
+            "\x0F\xBE\x93\x76\x01\x00\x00\x3B\xD1\x7D\x0D",
+            "xxxxxxxxxxx"
+        ) - 17,
+        2);
+}

--- a/Source/Sonic Origins/UI/Sonic 3 & Knuckles/Allow Amy in Classic Mode.hmm
+++ b/Source/Sonic Origins/UI/Sonic 3 & Knuckles/Allow Amy in Classic Mode.hmm
@@ -6,7 +6,7 @@ Notes;
 - Amy's Hammer Rush move will not activate in Classic Mode.
 */
 {
-    // Set option to wrap to when pressing up from Sonic & Tails on No Save
+    // Skip gameMode check when pressing up from Sonic & Tails on No Save
     // 2.0.2: 0x140307826
     WriteNop(
         ScanSignature
@@ -16,7 +16,7 @@ Notes;
         ) - 17,
         2);
 
-    // Set max option count when pressing down on No Save
+    // Skip gameMode check when pressing down on No Save
     // 2.0.2: 0x1403077E3
     WriteNop(
         ScanSignature
@@ -26,7 +26,7 @@ Notes;
         ) - 17,
         2);
 
-    // Set option to wrap to when pressing up from Sonic & Tails on a save file
+    // Skip gameMode check when pressing up from Sonic & Tails on a save file
     // 2.0.2: 0x140307CF3
     WriteNop(
         ScanSignature
@@ -36,7 +36,7 @@ Notes;
         ) - 30,
         2);
 
-    // Set max option count when pressing down on a save file
+    // Skip gameMode check when pressing down on a save file
     // 2.0.2: 0x140307C41
     WriteNop(
         ScanSignature

--- a/Source/Sonic Origins/UI/Sonic 3 & Knuckles/Allow Amy in Original Blue Spheres.hmm
+++ b/Source/Sonic Origins/UI/Sonic 3 & Knuckles/Allow Amy in Original Blue Spheres.hmm
@@ -1,0 +1,15 @@
+Patch "Allow Amy in Original Blue Spheres" in "UI/Sonic 3 & Knuckles" by "MegAmi" does
+/*
+Allows selecting and playing as Amy in Original Blue Spheres if the Plus DLC is active.
+
+Notes;
+- The stars on the bumper spheres in the menu will appear as black when Amy is selected.
+- Amy will not appear in the Blue Spheres Complete scene.
+*/
+//
+    #lib "Memory"
+//
+{
+    // 2.0.2: 0x1402E5322
+    Memory.WriteForceJump(ScanSignature("\x75\x07\xBA\x03\x00\x00\x00\xEB\x0B\x45\x85\xC0", "xxxxxxxxxxxx"));
+}


### PR DESCRIPTION
This PR adds the following Origins codes:
* Disable Ring Loss From Super/Hyper Forms
* Infinite Tails Flight
* Fix Star Post Fadeout
* Disable Bonus Stages
* Disable Cool Bonus
* Allow Amy in Classic Mode
* Allow Amy in Original Blue Spheres