### PR TITLE
[Sonic Origins] Add Force Bonus Stage codes

### DIFF
--- a/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Bonus Stages/Disable Bonus Stages.hmm
+++ b/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Bonus Stages/Disable Bonus Stages.hmm
@@ -1,4 +1,4 @@
-Patch "Disable Bonus Stages" in "Gameplay/Sonic 3 & Knuckles" by "MegAmi" does "Removes the Bonus Stage stars from Star Posts."
+Patch "Disable Bonus Stages" in "Gameplay/Sonic 3 & Knuckles/Bonus Stages" by "MegAmi" does "Removes the Bonus Stage stars from Star Posts."
 //
     #lib "Memory"
 //

--- a/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Bonus Stages/Force Gachapon Bonus Stage.hmm
+++ b/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Bonus Stages/Force Gachapon Bonus Stage.hmm
@@ -1,0 +1,14 @@
+Patch "Force Gachapon Bonus Stage" in "Gameplay/Sonic 3 & Knuckles/Bonus Stages" by "Lave sIime" does "Makes the Gachapon Bonus Stage the only one to appear from Star Posts. Does not remove the 20 rings requirement."
+{
+	WriteProtected<byte>
+	(
+		/* 2.0.2: 0x1401FA460 + 47 */
+		ScanSignature
+		(
+			"\x14\x0F\x8C\x28\x01\x00\x00\x83\xC1\xEC\xB8\x89\x88\x88\x88\xF7\xE9\x44\x8D\x04\x11\x41\xC1\xF8\x03",
+			"xxx????xxxxxxxxxxxxxxxxxx"
+		) + 47,
+		
+		Assemble("mov r8d, 2; nop; nop")
+	);
+}

--- a/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Bonus Stages/Force Glowing Spheres Bonus Stage.hmm
+++ b/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Bonus Stages/Force Glowing Spheres Bonus Stage.hmm
@@ -1,0 +1,14 @@
+Patch "Force Glowing Spheres Bonus Stage" in "Gameplay/Sonic 3 & Knuckles/Bonus Stages" by "Lave sIime" does "Makes the Glowing Spheres Bonus Stage the only one to appear from Star Posts. Does not remove the 20 rings requirement."
+{
+	WriteProtected<byte>
+	(
+		/* 2.0.2: 0x1401FA460 + 47 */
+		ScanSignature
+		(
+			"\x14\x0F\x8C\x28\x01\x00\x00\x83\xC1\xEC\xB8\x89\x88\x88\x88\xF7\xE9\x44\x8D\x04\x11\x41\xC1\xF8\x03",
+			"xxx????xxxxxxxxxxxxxxxxxx"
+		) + 47,
+		
+		Assemble("mov r8d, 1; nop; nop")
+	);
+}

--- a/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Bonus Stages/Force Rotating Slot Bonus Stage.hmm
+++ b/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Bonus Stages/Force Rotating Slot Bonus Stage.hmm
@@ -1,0 +1,14 @@
+Patch "Force Rotating Slot Bonus Stage" in "Gameplay/Sonic 3 & Knuckles/Bonus Stages" by "Lave sIime" does "Makes the Rotating Slot Bonus Stage the only one to appear from Star Posts. Does not remove the 20 rings requirement."
+{
+	WriteProtected<byte>
+	(
+		/* 2.0.2: 0x1401FA460 + 47 */
+		ScanSignature
+		(
+			"\x14\x0F\x8C\x28\x01\x00\x00\x83\xC1\xEC\xB8\x89\x88\x88\x88\xF7\xE9\x44\x8D\x04\x11\x41\xC1\xF8\x03",
+			"xxx????xxxxxxxxxxxxxxxxxx"
+		) + 47,
+		
+		Assemble("mov r8d, 0; nop; nop")
+	);
+}


### PR DESCRIPTION
Adds codes to force one of each of the three Bonus Stages in S3K, and creates a "Bonus Stage" category for them and the already existing "Disable Bonus Stages" code.