### PR TITLE
[Sonic Frontiers] Added code "Fix Squatting Animation"

### DIFF
--- a/Source/Sonic Frontiers/Fixes/Animation/Fix Squatting Animation.hmm
+++ b/Source/Sonic Frontiers/Fixes/Animation/Fix Squatting Animation.hmm
@@ -1,0 +1,2 @@
+Patch "Fix Squatting Animation" in "Fixes/Animation" by "angryzor" does "Plays the squat start animation when squatting from a standing pose."
+WriteProtected<byte>(0x14B83D5F7, 2);

--- a/Source/Sonic Frontiers/Fixes/Animation/Fix Squatting Animation.hmm
+++ b/Source/Sonic Frontiers/Fixes/Animation/Fix Squatting Animation.hmm
@@ -1,2 +1,10 @@
 Patch "Fix Squatting Animation" in "Fixes/Animation" by "angryzor" does "Plays the squat start animation when squatting from a standing pose."
-WriteProtected<byte>(0x14B83D5F7, 2);
+{
+    /* 0x14B83D5ED in 1.41 */
+    long stateSquatEnter = ScanSignature(
+        "\x48\x89\xc2\x83\xfd\x3a\x74\x17\x83\xfd\x01\x48\x8d\x05\x59\xef\xcf\xf5\x48\x8d\x1d\xaa\x6f\xc5\xf5\x48\x0f\x45\xd8\xeb\x07\x48\x8d\x1d\x45\xef\xcf\xf5\x48\x89\xf9\xe8\x95\x88\x4f\xf5\x48\x89\xc1\x41\xb0\xfe\x48\x89\xda\xe8",
+        "xxxxxxxxxxxxxx????xxx????xxxxxxxxx????xxxx????xxxxxxxxxx"
+    );
+
+    WriteProtected<byte>(stateSquatEnter + 0xA, 2);
+}


### PR DESCRIPTION
Due to what looks like a bug (the code checks if the previous state ID was 1 (StateStandRoot), where it probably intended to check if the player was standing previously (ID 2, StateStand)), Sonic skips the SQUAT animation state and goes straight to SQUAT_LOOP instead. This code fixes that.