### PR TITLE
[Sonic Origins] Add "Force P2" codes to S3&K Cheat section

### DIFF
--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Amy.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Amy.hmm
@@ -10,6 +10,8 @@ Code "P2 Always Amy" in "Cheats/Sonic 3 & Knuckles" by "KiaraGale" does "Forces 
     if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4C350C) == (int)0)
 	return;
 
-    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Amy)
+    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Amy) {
+	*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) &= ~(int)(255 << 8);
         *(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) |= (int)RSDK.S3KPlayer.Amy << 8;
+    }
 }

--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Amy.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Amy.hmm
@@ -1,0 +1,15 @@
+Code "P2 Always Amy" in "Cheats/Sonic 3 & Knuckles" by "KiaraGale" does "Forces P2 to be Amy if Plus DLC is active, regardless of in-game sidekick choice."
+//
+    #lib "RSDK"
+//
+{
+    if (RSDK.GetRSDKGlobalsPtr() == 0)
+        return;
+
+    // no plus dlc, no amy!
+    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4C350C) == (int)0)
+	return;
+
+    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Amy)
+        *(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) |= (int)RSDK.S3KPlayer.Amy << 8;
+}

--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Knuckles.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Knuckles.hmm
@@ -1,0 +1,10 @@
+Code "P2 Always Knuckles" in "Cheats/Sonic 3 & Knuckles" by "KiaraGale" does "Forces P2 to be Knuckles, regardless of in-game sidekick choice."
+//
+    #lib "RSDK"
+//
+{
+    if (RSDK.GetRSDKGlobalsPtr() == 0)
+        return;
+
+    *(int*)(RSDK.GetRSDKGlobalsPtr() + 0xC2CB4) |= (int)RSDK.S3KMedalMod.AndKnuckles;
+}

--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Sonic.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Sonic.hmm
@@ -6,6 +6,8 @@ Code "P2 Always Sonic" in "Cheats/Sonic 3 & Knuckles" by "KiaraGale" does "Force
     if (RSDK.GetRSDKGlobalsPtr() == 0)
         return;
 
-    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Sonic)
+    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Sonic) {
+	*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) &= ~(int)(255 << 8);
         *(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) |= (int)RSDK.S3KPlayer.Sonic << 8;
+    }
 }

--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Sonic.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Sonic.hmm
@@ -1,0 +1,11 @@
+Code "P2 Always Sonic" in "Cheats/Sonic 3 & Knuckles" by "KiaraGale" does "Forces P2 to be Sonic, regardless of in-game sidekick choice."
+//
+    #lib "RSDK"
+//
+{
+    if (RSDK.GetRSDKGlobalsPtr() == 0)
+        return;
+
+    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Sonic)
+        *(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) |= (int)RSDK.S3KPlayer.Sonic << 8;
+}

--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Tails.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Tails.hmm
@@ -6,6 +6,8 @@ Code "P2 Always Tails" in "Cheats/Sonic 3 & Knuckles" by "KiaraGale" does "Force
     if (RSDK.GetRSDKGlobalsPtr() == 0)
         return;
 
-    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Tails)
+    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Tails) {
+	*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) &= ~(int)(255 << 8);
         *(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) |= (int)RSDK.S3KPlayer.Tails << 8;
+    }
 }

--- a/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Tails.hmm
+++ b/Source/Sonic Origins/Cheats/Sonic 3 & Knuckles/P2 Always Tails.hmm
@@ -1,0 +1,11 @@
+Code "P2 Always Tails" in "Cheats/Sonic 3 & Knuckles" by "KiaraGale" does "Forces P2 to be Tails, regardless of in-game sidekick choice."
+//
+    #lib "RSDK"
+//
+{
+    if (RSDK.GetRSDKGlobalsPtr() == 0)
+        return;
+
+    if (*(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) >> 8 != (int)RSDK.S3KPlayer.Tails)
+        *(int*)(RSDK.GetRSDKGlobalsPtr() + 0x4) |= (int)RSDK.S3KPlayer.Tails << 8;
+}


### PR DESCRIPTION
I've made codes to force-set player 2 in S3&K to a certain character, similar to the Mania Mod Manager codes, and figured people would appreciate this for Origins as well.
Amy's code in particular checks for the Plus DLC being active, so there are no concerns about using this to circumvent Amy's Plus DLC requirement.