### PR TITLE
[Sonic Frontiers] Fix crash in Cameras library

### DIFF
--- a/Source/Sonic Frontiers/Libraries/Cameras.hmm
+++ b/Source/Sonic Frontiers/Libraries/Cameras.hmm
@@ -207,6 +207,9 @@ Library "Cameras" by "Hyper"
         /// <param name="in_degrees">The field of view in degrees.</param>
         public void SetFieldOfView(float in_degrees)
         {
+            if (pStandardCameraConfig == null)
+                return;
+
             float fovY = FieldOfViewY * pStandardCameraConfig->option.minFovyRate;
 
             // HACK (Hyper): temporary fix, limits FOV to 0-89 to prevent unstable game state.


### PR DESCRIPTION
It certain points in time this pointer may be `null` (e.g. for a fraction of a second when switching characters). This call will then crash. This happens for example when the "Playable Amy, Tails and Knuckles" mod is used together with the "Open Zone FOV" code.