### PR TITLE
[Shadow Generations] Disable Wind Overlay code

### DIFF
--- a/Source/Shadow Generations/Graphics/Post-processing/Disable Wind Overlay Effect.hmm
+++ b/Source/Shadow Generations/Graphics/Post-processing/Disable Wind Overlay Effect.hmm
@@ -1,0 +1,12 @@
+Patch "Disable Wind Overlay Effect" in "Graphics/Post-processing" by "stis" does "Disables the wind effect when boosting"
+{
+    WriteProtected<byte>(
+        /* v1.1.0.1: 0x14120FF38 */
+        ScanSignature
+        (
+            "\x65\x66\x5F\x70\x6C\x5F\x6C\x69\x6E\x65\x5F\x73\x70\x65\x65\x64\x30\x31",
+            "xxxxxxxxxxxxxxxxxx"
+        ),
+        0x30
+    );
+}


### PR DESCRIPTION
This code disables very famous wind effect from Forces (maybe LW also counts)
a lot of people seems to be annoyed by its presence

Screen with Wind effect
![WITH EFFECT](https://github.com/user-attachments/assets/cf2931be-ec40-44f4-9c72-d96af04d91c9)
![WITH_EFFECT_2](https://github.com/user-attachments/assets/c17cce98-fe3f-48a6-88d5-6f3369a09f6c)

Without it
![NO EFFECT](https://github.com/user-attachments/assets/773878de-bf63-4c96-b3a8-1a45186d4e95)
![NO_EFFECT_2](https://github.com/user-attachments/assets/95ec0b9d-b080-4760-900c-f12dac3b57aa)
