### PR TITLE
[Unleashed Recomp] Add "Disable D-Pad Movement" code

### DIFF
--- a/Source/Unleashed Recompiled/Gameplay/Disable D-Pad Movement.hmm
+++ b/Source/Unleashed Recompiled/Gameplay/Disable D-Pad Movement.hmm
@@ -1,0 +1,1 @@
+Patch "Disable D-Pad Movement" id "DisableDPadMovement" in "Gameplay" does "Disables Unleashed Recompiled's built-in D-Pad support for player and world map movement."

--- a/Source/Unleashed Recompiled/Gameplay/Disable DPad as Analog Input.hmm
+++ b/Source/Unleashed Recompiled/Gameplay/Disable DPad as Analog Input.hmm
@@ -1,1 +1,0 @@
-Patch "Disable DPad as Analog Input" id "DisableDPadAsAnalogInput" in "Gameplay" by "Refrag" does "Disables handling the directional pad as analog input (the dpad still works for the game menus)."

--- a/Source/Unleashed Recompiled/Gameplay/Disable DPad as Analog Input.hmm
+++ b/Source/Unleashed Recompiled/Gameplay/Disable DPad as Analog Input.hmm
@@ -1,0 +1,1 @@
+Patch "Disable DPad as Analog Input" id "DisableDPadAsAnalogInput" in "Gameplay" by "Refrag" does "Disables handling the directional pad as analog input (the dpad still works for the game menus)."


### PR DESCRIPTION
Enabling this code will disable analog movement with the dpad (Sonic's movement, the world map cursor movement...). The dpad will still work for the menus.

See https://github.com/hedge-dev/UnleashedRecomp/pull/604.
Note : this code is not available already in the current version (1.0.1). It is set to release as of version 1.0.2 of Unleashed Recomp.