### PR TITLE
[Sonic Origins] Audio-related codes, code fixes

### DIFF
--- a/Source/Sonic Origins/Audio/Sonic 1/Use Sonic CD Jump Sound.hmm
+++ b/Source/Sonic Origins/Audio/Sonic 1/Use Sonic CD Jump Sound.hmm
@@ -1,0 +1,7 @@
+Patch "Use Sonic CD Jump Sound" in "Audio/Sonic 1" by "Lave sIime" does "Replaces Sonic 1's jump sound effect with Sonic CD's unique one."
+{
+    #lib "AudioRedirection"
+    #lib "RSDK"
+    
+    AudioRedirection.AddSoundReplacement(RSDK.Game.Sonic1, "Global/Jump.wav", "SFX_SCD_F02_Jump");
+}

--- a/Source/Sonic Origins/Audio/Sonic 2/Use Sonic CD Jump Sound.hmm
+++ b/Source/Sonic Origins/Audio/Sonic 2/Use Sonic CD Jump Sound.hmm
@@ -1,0 +1,7 @@
+Patch "Use Sonic CD Jump Sound" in "Audio/Sonic 2" by "Lave sIime" does "Replaces Sonic 2's jump sound effect with Sonic CD's unique one."
+{
+    #lib "AudioRedirection"
+    #lib "RSDK"
+    
+    AudioRedirection.AddSoundReplacement(RSDK.Game.Sonic2, "Global/Jump.ogg", "SFX_SCD_F02_Jump");
+}

--- a/Source/Sonic Origins/Audio/Sonic 3 & Knuckles/Disable Super Music.hmm
+++ b/Source/Sonic Origins/Audio/Sonic 3 & Knuckles/Disable Super Music.hmm
@@ -1,14 +1,21 @@
-Code "Disable Super Music" in "Audio/Sonic 3 & Knuckles" by "MegAmi" does
-/*
-Forces the flag for the Super music in Sonic 3 & Knuckles to be disabled.
-
-Notes;
-- Due to how the Super music is coded, it may still play in some instances, such as after the AIZ Act 1 bombing cutscene.
-*/
+Code "Disable Super Music" in "Audio/Sonic 3 & Knuckles" by "MegAmi & Lave sIime" does "Forces the Super music in Sonic 3 & Knuckles to be disabled."
 //
     #lib "RSDK"
+
+    static bool _isInitialised = false;
 //
 {
+    if (!_isInitialised)
+    {
+        // 2.0.2: 0x1401D555A
+        Memory.WriteForceJump(ScanSignature("\x75\x07\xB9\x09\x00\x00\x00\xEB\x02\x33\xC9", "x?xxxxxx?xx"));
+
+        // 2.0.2: 0x1401D4DA0
+        Memory.WriteForceJump(ScanSignature("\x75\x50\xBB\x28\x00\x00\x00\x66\x0F\x1F\x84\x00\x00\x00\x00\x00", "x?xxxxxxxxxxxxxx"));
+
+        _isInitialised = true;
+    }
+
     if (RSDK.GetRSDKGlobalsPtr() == 0)
         return;
 

--- a/Source/Sonic Origins/Audio/Sonic 3 & Knuckles/Use Sonic CD Jump Sound.hmm
+++ b/Source/Sonic Origins/Audio/Sonic 3 & Knuckles/Use Sonic CD Jump Sound.hmm
@@ -1,0 +1,7 @@
+Patch "Use Sonic CD Jump Sound" in "Audio/Sonic 3 & Knuckles" by "Lave sIime" does "Replaces Sonic 3's jump sound effect with Sonic CD's unique one."
+{
+    #lib "AudioRedirection"
+    #lib "RSDK"
+    
+    AudioRedirection.AddSoundReplacement(RSDK.Game.Sonic3k, "Global/Jump.wav", "SFX_SCD_F02_Jump");
+}

--- a/Source/Sonic Origins/Audio/Sonic CD/Random Soundtrack Region.hmm
+++ b/Source/Sonic Origins/Audio/Sonic CD/Random Soundtrack Region.hmm
@@ -1,0 +1,49 @@
+Patch "Random Soundtrack Region" in "Audio/Sonic CD" by "Lave sIime" does
+/*
+Individually randomizes the soundtrack region for every applicable song in the game.
+
+Notes;
+- Act Results timings and Invincibility duration will still be controlled by the in-game soundtrack setting.
+*/
+{
+    #include "Helpers" noemit
+    private static Random _rand = new Random();
+    
+    static class MusicTrackHook
+    {
+        UNMANAGED_FUNCTION(string, SetMusicTrack, string filePath)
+        {
+            // Nothing too complicated - if we start with a region prefix, then just replace it with a random one
+            if (filePath != null && (filePath.StartsWith("US") || filePath.StartsWith("JP")))
+            {
+                filePath = ((_rand.NextDouble() > 0.5) ? "US" : "JP") + filePath.Substring(2);
+                
+                // Special exception: JP/TimeAttack.ogg exists but there's no US version, so replace it with the DA Garden theme (as does the base game already)
+                if (filePath == "JP/TimeAttack.ogg")
+                    filePath = "US/DAGarden.ogg";
+            }
+            
+            return filePath;
+        }
+    }
+    
+    WriteAsmHook
+    (
+        $@"
+            push rax
+            push rdx
+            push r9
+            
+            mov  rax, {MusicTrackHook._fpSetMusicTrack}
+            call rax
+            mov  rcx, rax
+            
+            pop r9
+            pop rdx
+            pop rax
+        ",
+        /* 2.0.2: 0x1400A468F */
+        ScanSignature("\x57\x48\x83\xEC\x20\x8B\xC2\x41\x0F\xB6\xF0\x83\xE0\x0F", "xxxxxxxxxxxxxx"),
+        HookBehavior.After
+    );
+}

--- a/Source/Sonic Origins/Audio/Sonic CD/Use Sonic 1 Jump Sound.hmm
+++ b/Source/Sonic Origins/Audio/Sonic CD/Use Sonic 1 Jump Sound.hmm
@@ -1,0 +1,7 @@
+Patch "Use Sonic 1 Jump Sound" in "Audio/Sonic CD" by "Lave sIime" does "Replaces Sonic CD's unique jump sound effect with the one used in Sonic 1."
+{
+    #lib "AudioRedirection"
+    #lib "RSDK"
+    
+    AudioRedirection.AddSoundReplacement(RSDK.Game.SonicCD, "Global/Jump.wav", "SFX_A0_Jump");
+}

--- a/Source/Sonic Origins/Fixes/Sonic 2/Fix Insta-Shield Sound.hmm
+++ b/Source/Sonic Origins/Fixes/Sonic 2/Fix Insta-Shield Sound.hmm
@@ -1,0 +1,7 @@
+Patch "Fix Insta-Shield Sound" in "Fixes/Sonic 2" by "Lave sIime" does "Fixes the Insta-Shield playing the wrong sound effect in Sonic 2."
+{
+    #lib "AudioRedirection"
+    #lib "RSDK"
+    
+    AudioRedirection.AddSoundReplacement(RSDK.Game.Sonic2, "Global/InstaShield.ogg", "S015_S42_InstaShield");
+}

--- a/Source/Sonic Origins/Fixes/Sonic 2/Fix Knuckles Landing Sound.hmm
+++ b/Source/Sonic Origins/Fixes/Sonic 2/Fix Knuckles Landing Sound.hmm
@@ -1,0 +1,7 @@
+Patch "Fix Knuckles Landing Sound" in "Fixes/Sonic 2" by "Lave sIime" does "Fixes Knuckles playing the wrong sound effect when landing from a glide in Sonic 2."
+{
+    #lib "AudioRedirection"
+    #lib "RSDK"
+    
+    AudioRedirection.AddSoundReplacement(RSDK.Game.Sonic2, "Global/Landing.ogg", "RSDK-1---Landing");
+}

--- a/Source/Sonic Origins/Fixes/Sonic 3 & Knuckles/Fix Missing Menu Fail Sound.hmm
+++ b/Source/Sonic Origins/Fixes/Sonic 3 & Knuckles/Fix Missing Menu Fail Sound.hmm
@@ -1,0 +1,7 @@
+Patch "Fix Missing Menu Fail Sound" in "Fixes/Sonic 3 & Knuckles" by "Lave sIime" does "Fixes the missing Fail sound after trying to input an invalid stage code in the Blue Spheres menu."
+{
+    #lib "AudioRedirection"
+    #lib "RSDK"
+    
+    AudioRedirection.AddSoundReplacement(RSDK.Game.Sonic3k, "Stage/Fail.wav", "S127_SB2_Fail");
+}

--- a/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Abilities/Sonic/Enable Super Peel Out.hmm
+++ b/Source/Sonic Origins/Gameplay/Sonic 3 & Knuckles/Abilities/Sonic/Enable Super Peel Out.hmm
@@ -39,6 +39,30 @@ Notes;
             HookBehavior.Replace
         );
 
+        // Fix the Super Peel Out always sending the player right in reverse gravity
+        WriteAsmHook
+        (
+            $@"
+                neg eax
+                
+                ; original instruction: cmp byte ptr [rbx + 0x56], 00
+                ; instead of comparing the entire byte, let's check only the low bit (aka the x flip bit, ignoring the y flip bit)
+                movzx edx, byte ptr [rbx + 0x56]
+                and dl, 01
+                cmovne ecx, eax
+                
+                xor edx, edx
+                mov [rbx + 0x34], ecx
+            ",
+            /* Player::State_Peelout - 2.0.2: 0x1401EB828 */
+            ScanSignature
+            (
+                "\xF7\xD8\x80\x7B\x56\x00\x0F\x45\xC8\x33\xD2\x89\x4B\x34",
+                "xxxxxxxxxxxxxx"
+            ),
+            HookBehavior.Replace
+        );
+
         _isInitialised = true;
     }
 

--- a/Source/Sonic Origins/Libraries/AudioRedirection.hmm
+++ b/Source/Sonic Origins/Libraries/AudioRedirection.hmm
@@ -292,12 +292,9 @@ Library "AudioRedirection" by "Lave sIime"
                 mov  rax, {GET_UNMANAGED_FUNCTION_PTR(MusicReplacement)}
                 call rax
                 
-                ; replacement found?
+                ; if we didn't find a replacement, let's stick with the original result
                 test rax, rax
-                jnz  found
-                
-                ; nope, let's stick with the original result
-                mov  rax, rbx
+                cmovz rax, rbx
                 
             found:
                 pop  r11
@@ -319,15 +316,13 @@ Library "AudioRedirection" by "Lave sIime"
         (
             $@"
                 mov  rcx, rsi
+                mov  rdi, rax
                 mov  rax, {GET_UNMANAGED_FUNCTION_PTR(SoundReplacement)}
                 call rax
                 
-                ; replacement found?
+                ; if we didn't find a replacement, let's stick with the original result
                 test rax, rax
-                jnz  found
-                
-                ; nope, let's stick with the original result
-                mov  rax, rdi
+                cmovz rax, rdi
                 
             found:
                 mov rbx, [rsp + 0x30]

--- a/Source/Sonic Origins/Libraries/AudioRedirection.hmm
+++ b/Source/Sonic Origins/Libraries/AudioRedirection.hmm
@@ -296,7 +296,6 @@ Library "AudioRedirection" by "Lave sIime"
                 test rax, rax
                 cmovz rax, rbx
                 
-            found:
                 pop  r11
                 pop  r10
                 mov  rbx, [r11 + 0x10]
@@ -324,7 +323,6 @@ Library "AudioRedirection" by "Lave sIime"
                 test rax, rax
                 cmovz rax, rdi
                 
-            found:
                 mov rbx, [rsp + 0x30]
                 mov rbp, [rsp + 0x38]
                 mov rsi, [rsp + 0x40]


### PR DESCRIPTION
Fixes some issues with existing codes:
- "Disable Super Music" for Sonic 3k: Properly disable the super music in all scenarios where it would previously still play.
- "Enable Super Peel Out" for Sonic 3k: Fix the move sending the player in the wrong direction when under inverse gravity.
- AudioRedirerction library: Fix an issue where, when the game would attempt to play an RSDK sfx with no matching cue in the Reflection data, the library could sometimes play a random unrelated sound effect instead of doing nothing.

Additionally, some new audio related codes are included as well:
- "Use Sonic CD Jump Sound" for Sonic 1, 2, 3k: Replaces the jump sound in each of those games with Sonic CD's unique jumping sound.
- "Use Sonic 1 Jump Sound" for Sonic CD: The inverse of the above, where it replaces Sonic CD's unique jumping sound with the one used in Sonic 1.
- "Random Soundtrack Region" for Sonic CD: Randomises the soundtrack region for every region-specific song in the game.
- "Fix Insta-Shield Sound" for Sonic 2: Fixes the sound effect being matched to the incorrect cue.
- "Fix Knuckles Landing Sound" for Sonic 2: Similarly fixes the sound effect playing the incorrect sound.